### PR TITLE
Add missing runtime dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,11 @@ llm_client.py
 
 ### Requirements
 ```
+anthropic>=0.29.0
 openai>=1.0.0
 python-dotenv>=1.0.0
-tqdm>=4.66.0
-anthropic
+requests>=2.31.0
+tqdm>=4.66.1
 ```
 Install:
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
+anthropic>=0.29.0
 openai>=1.0.0
 python-dotenv>=1.0.0
+requests>=2.31.0
+tqdm>=4.66.1


### PR DESCRIPTION
## Summary
- include anthropic in dependencies for Anthropic model support
- document full dependency list in README with version pins

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement anthropic>=0.29.0; Cannot connect to proxy)*
- `pytest`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68973d0d9d748321ad572d294fc66226