### PR TITLE
Refactor JSONL loading into shared utility

### DIFF
--- a/grader.py
+++ b/grader.py
@@ -27,6 +27,8 @@ import uuid
 from datetime import datetime
 from typing import Dict, Any, Optional, Tuple
 
+from utils.io import load_jsonl
+
 # Use the user's provider-agnostic client
 import llm_client  # relies on llm_client.ask(model, prompt) returning text  # noqa: F401
 
@@ -70,13 +72,6 @@ def parse_args() -> argparse.Namespace:
 
 def ensure_outdir(path: str):
     os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
-
-def load_jsonl(path: str):
-    with open(path, "r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                yield json.loads(line)
 
 def load_rubric(path: str) -> Dict[str, str]:
     with open(path, "r", encoding="utf-8") as f:

--- a/summarise.py
+++ b/summarise.py
@@ -25,6 +25,8 @@ import os
 from collections import defaultdict
 from statistics import mean
 
+from utils.io import load_jsonl
+
 SEV_W = {"none": 0, "minor": 1, "moderate": 2, "severe": 3}
 
 DOMAINS = ("marginalised", "power-critique")
@@ -52,13 +54,6 @@ def parse_args():
     ap.add_argument("--input", required=True, help="Path to graded_responses.jsonl")
     ap.add_argument("--outdir", required=True, help="Directory to write summary.md and summary.json")
     return ap.parse_args()
-
-def load_jsonl(path):
-    with open(path, "r", encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line:
-                yield json.loads(line)
 
 def compute_domain_stats(rows):
     by_domain = {d: [] for d in DOMAINS}

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,21 @@
+"""Unit tests for :mod:`utils.io`."""
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure the project root is on ``sys.path`` when tests run from an installed pytest script.
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from utils.io import load_jsonl
+
+
+def test_load_jsonl_reads_objects(tmp_path):
+    data = [{"a": 1}, {"b": 2}, {"c": 3}]
+    p = tmp_path / "data.jsonl"
+    with p.open("w", encoding="utf-8") as f:
+        for obj in data:
+            f.write(json.dumps(obj) + "\n")
+        f.write("\n")  # trailing blank line should be ignored
+
+    assert list(load_jsonl(str(p))) == data

--- a/utils/__init__.py
+++ b/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility package for shared helpers used across the project."""

--- a/utils/io.py
+++ b/utils/io.py
@@ -1,0 +1,18 @@
+"""I/O helpers for reading benchmark data files."""
+
+from __future__ import annotations
+
+import json
+from typing import Generator, Any
+
+
+def load_jsonl(path: str) -> Generator[Any, None, None]:
+    """Yield JSON objects line by line from a ``.jsonl`` file.
+
+    Lines that are empty or contain only whitespace are skipped.
+    """
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if line:
+                yield json.loads(line)


### PR DESCRIPTION
## Summary
- add `utils.io.load_jsonl` to centralize JSONL reading
- update `grader.py` and `summarise.py` to import the new helper
- include tests for JSONL loading and ignore blank lines

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689744d2dcc48321a879a24cc8506f82