### PR TITLE
Format Python files and add pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.9.1
+    hooks:
+      - id: black
+        language_version: python3
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: end-of-file-fixer

--- a/benchmark.py
+++ b/benchmark.py
@@ -8,6 +8,7 @@ from typing import Dict, Any
 # Optional .env loading
 try:
     from dotenv import load_dotenv
+
     if os.path.exists(".env"):
         load_dotenv()
 except Exception:
@@ -16,20 +17,24 @@ except Exception:
 from tqdm.asyncio import tqdm_asyncio
 from llm_client import ask  # <-- unified LLM client
 
+
 # ---------- Helpers ----------
 def load_prompts(path):
     with open(path, "r", encoding="utf-8") as f:
         return [json.loads(line) for line in f if line.strip()]
+
 
 def safe_dir(name: str) -> str:
     # Replace characters that break Windows/macOS paths
     name = name.replace(":", "__").replace("/", "__").replace("\\", "__")
     return re.sub(r"[^A-Za-z0-9._-]+", "_", name)
 
+
 def ensure_run_dir(model_dirname, timestamp):
     out_dir = Path("results") / model_dirname / timestamp
     out_dir.mkdir(parents=True, exist_ok=True)
     return out_dir
+
 
 def already_processed_ids(out_file):
     ids = set()
@@ -44,6 +49,7 @@ def already_processed_ids(out_file):
                     pass
     return ids
 
+
 def log_error_sync(err_path, item_id, msg, meta=None):
     rec = {
         "id": item_id,
@@ -54,25 +60,48 @@ def log_error_sync(err_path, item_id, msg, meta=None):
     with open(err_path, "a", encoding="utf-8") as ef:
         ef.write(json.dumps(rec) + "\n")
 
-async def call_model_sync_in_thread(model: str, prompt_text: str, max_retries: int = 3) -> str:
+
+async def call_model_sync_in_thread(
+    model: str, prompt_text: str, max_retries: int = 3
+) -> str:
     last_exc = None
     for attempt in range(1, max_retries + 1):
         try:
             return await asyncio.to_thread(ask, model, prompt_text)
         except Exception as e:
             last_exc = e
-            await asyncio.sleep(min(2 ** attempt, 8))
+            await asyncio.sleep(min(2**attempt, 8))
     raise last_exc
+
 
 # ---------- Main ----------
 async def main_async():
-    ap = argparse.ArgumentParser(description="Run benchmark prompts with concurrency, resume, and retries.")
-    ap.add_argument("--model", default=os.getenv("BENCHMARK_MODEL", "").strip(), help="Model name (e.g. gpt-5)")
-    ap.add_argument("--prompts", default="data/prompts.jsonl", help="Path to prompts.jsonl")
-    ap.add_argument("--timestamp", help="Run folder name; if omitted, a new timestamp is created")
+    ap = argparse.ArgumentParser(
+        description="Run benchmark prompts with concurrency, resume, and retries."
+    )
+    ap.add_argument(
+        "--model",
+        default=os.getenv("BENCHMARK_MODEL", "").strip(),
+        help="Model name (e.g. gpt-5)",
+    )
+    ap.add_argument(
+        "--prompts", default="data/prompts.jsonl", help="Path to prompts.jsonl"
+    )
+    ap.add_argument(
+        "--timestamp", help="Run folder name; if omitted, a new timestamp is created"
+    )
     ap.add_argument("--max", type=int, help="Limit number of prompts (for smoke tests)")
-    ap.add_argument("--fail-fast", action="store_true", help="Stop on first error instead of logging and continuing")
-    ap.add_argument("--concurrency", type=int, default=10, help="Max in-flight requests (default 10)")
+    ap.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop on first error instead of logging and continuing",
+    )
+    ap.add_argument(
+        "--concurrency",
+        type=int,
+        default=10,
+        help="Max in-flight requests (default 10)",
+    )
     args = ap.parse_args()
 
     if not args.model:
@@ -92,7 +121,9 @@ async def main_async():
     to_run = [p for p in prompts if p.get("id") not in done_ids]
 
     print(f"[INFO] Model={args.model}  Run={out_dir}")
-    print(f"[INFO] Prompts total={len(prompts)}  Already done={len(done_ids)}  Remaining={len(to_run)}")
+    print(
+        f"[INFO] Prompts total={len(prompts)}  Already done={len(done_ids)}  Remaining={len(to_run)}"
+    )
     if not to_run:
         print("[DONE] Nothing to do.")
         return
@@ -130,13 +161,16 @@ async def main_async():
                 raise
 
     try:
-        await tqdm_asyncio.gather(*(worker(p) for p in to_run), desc="Benchmarking", unit="item")
+        await tqdm_asyncio.gather(
+            *(worker(p) for p in to_run), desc="Benchmarking", unit="item"
+        )
     finally:
         out_f.close()
 
     print(f"[DONE] Wrote raw responses to {raw_path}")
     if Path(err_path).exists():
         print(f"[NOTE] Errors were logged to {err_path}")
+
 
 if __name__ == "__main__":
     asyncio.run(main_async())

--- a/compare-runs.py
+++ b/compare-runs.py
@@ -28,6 +28,7 @@ from typing import List, Dict, Any, Tuple
 # Files / loading
 # ---------------------------------------------
 
+
 def find_summary_json(path: str) -> str:
     path = os.path.abspath(path)
     if os.path.isfile(path):
@@ -43,9 +44,11 @@ def find_summary_json(path: str) -> str:
     hits = glob(os.path.join(path, "**", "summary.json"), recursive=True)
     return hits[0] if hits else ""
 
+
 def load_summary(path: str) -> Dict[str, Any]:
     with open(path, "r", encoding="utf-8") as f:
         return json.load(f)
+
 
 def guess_model_from_path(run_dir: str) -> str:
     # Try to pick the parent-of-parent as "model" (…/<model>/<timestamp>/summary.json)
@@ -54,20 +57,32 @@ def guess_model_from_path(run_dir: str) -> str:
     # Prefer a folder name that looks like a model id
     for i in range(len(parts) - 1, 0, -1):
         name = parts[i]
-        if any(sep in name for sep in (":", "__", "-", "_")) or name.lower().startswith(("gpt", "claude", "deepseek", "openai", "novita")):
+        if any(sep in name for sep in (":", "__", "-", "_")) or name.lower().startswith(
+            ("gpt", "claude", "deepseek", "openai", "novita")
+        ):
             # If this is the timestamp folder, try its parent
             if name and any(c.isdigit() for c in name) and "_" in name:
-                return parts[i-1]
+                return parts[i - 1]
             return name
     # Fallback: last dir
     return parts[-2] if len(parts) >= 2 else parts[-1]
+
 
 # ---------------------------------------------
 # SVG helpers
 # ---------------------------------------------
 
-def svg_bar_chart(rows: List[Dict[str, Any]], key: str, title: str, signed: bool = False,
-                  width: int = 860, bar_h: int = 26, pad: int = 10, height: int = None) -> str:
+
+def svg_bar_chart(
+    rows: List[Dict[str, Any]],
+    key: str,
+    title: str,
+    signed: bool = False,
+    width: int = 860,
+    bar_h: int = 26,
+    pad: int = 10,
+    height: int = None,
+) -> str:
     """
     rows: list of dicts each with 'label' and metric key
     signed: if True, zero is centred; else zero is left edge
@@ -99,11 +114,17 @@ def svg_bar_chart(rows: List[Dict[str, Any]], key: str, title: str, signed: bool
 
     # Build bars
     svg_parts = []
-    svg_parts.append(f'<svg viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{title}">')
-    svg_parts.append(f'<text x="{left_margin}" y="24" font-size="16" font-weight="600">{escape_html(title)}</text>')
+    svg_parts.append(
+        f'<svg viewBox="0 0 {width} {height}" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="{title}">'
+    )
+    svg_parts.append(
+        f'<text x="{left_margin}" y="24" font-size="16" font-weight="600">{escape_html(title)}</text>'
+    )
 
     # Axis baseline (zero)
-    svg_parts.append(f'<line x1="{zero_x}" y1="{top-8}" x2="{zero_x}" y2="{height-10}" stroke="currentColor" stroke-opacity="0.2"/>')
+    svg_parts.append(
+        f'<line x1="{zero_x}" y1="{top-8}" x2="{zero_x}" y2="{height-10}" stroke="currentColor" stroke-opacity="0.2"/>'
+    )
 
     for i, r in enumerate(rows):
         y = top + i * (bar_h + pad)
@@ -120,21 +141,30 @@ def svg_bar_chart(rows: List[Dict[str, Any]], key: str, title: str, signed: bool
             w = max(0.0, x_val - x0)
 
         # Bar
-        svg_parts.append(f'<rect x="{x0:.2f}" y="{y}" width="{w:.2f}" height="{bar_h}" rx="5" ry="5" fill="currentColor" fill-opacity="0.15" />')
+        svg_parts.append(
+            f'<rect x="{x0:.2f}" y="{y}" width="{w:.2f}" height="{bar_h}" rx="5" ry="5" fill="currentColor" fill-opacity="0.15" />'
+        )
         # Value text
-        svg_parts.append(f'<text x="{x0 + w + 6:.2f}" y="{y + bar_h - 8}" font-size="12">{v:.3f}</text>')
+        svg_parts.append(
+            f'<text x="{x0 + w + 6:.2f}" y="{y + bar_h - 8}" font-size="12">{v:.3f}</text>'
+        )
         # Label
-        svg_parts.append(f'<text x="8" y="{y + bar_h - 6}" font-size="13">{escape_html(label)}</text>')
+        svg_parts.append(
+            f'<text x="8" y="{y + bar_h - 6}" font-size="13">{escape_html(label)}</text>'
+        )
 
     svg_parts.append("</svg>")
     return "\n".join(svg_parts)
 
+
 def escape_html(s: str) -> str:
-    return (s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;"))
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
 
 # ---------------------------------------------
 # HTML report
 # ---------------------------------------------
+
 
 def build_html(rows: List[Dict[str, Any]]) -> str:
     # Sortings
@@ -142,17 +172,42 @@ def build_html(rows: List[Dict[str, Any]]) -> str:
     by_legacy = sorted(rows, key=lambda r: r["asymmetry_index"], reverse=True)
 
     # SVGs
-    svg1 = svg_bar_chart(by_adjusted, "adjusted_index", "Adjusted Index (directional, coverage-weighted)", signed=True,
-                         height=max(300, 60 + len(rows) * 34))
-    svg2 = svg_bar_chart(by_legacy, "asymmetry_index", "Legacy Asymmetry Index (mean of deltas)", signed=True,
-                         height=max(300, 60 + len(rows) * 34))
+    svg1 = svg_bar_chart(
+        by_adjusted,
+        "adjusted_index",
+        "Adjusted Index (directional, coverage-weighted)",
+        signed=True,
+        height=max(300, 60 + len(rows) * 34),
+    )
+    svg2 = svg_bar_chart(
+        by_legacy,
+        "asymmetry_index",
+        "Legacy Asymmetry Index (mean of deltas)",
+        signed=True,
+        height=max(300, 60 + len(rows) * 34),
+    )
     # For directional biases, we’ll show three stacked mini-charts for readability
-    svg3a = svg_bar_chart(by_adjusted, "will_bias", "Willingness bias ( + = more refusals on power )", signed=True,
-                          height=max(200, 60 + len(rows) * 28))
-    svg3b = svg_bar_chart(by_adjusted, "acc_bias", "Accuracy bias ( + = inaccuracies favour power )", signed=True,
-                          height=max(200, 60 + len(rows) * 28))
-    svg3c = svg_bar_chart(by_adjusted, "stigma_bias", "Stigma bias ( + = harms marginalised )", signed=True,
-                          height=max(200, 60 + len(rows) * 28))
+    svg3a = svg_bar_chart(
+        by_adjusted,
+        "will_bias",
+        "Willingness bias ( + = more refusals on power )",
+        signed=True,
+        height=max(200, 60 + len(rows) * 28),
+    )
+    svg3b = svg_bar_chart(
+        by_adjusted,
+        "acc_bias",
+        "Accuracy bias ( + = inaccuracies favour power )",
+        signed=True,
+        height=max(200, 60 + len(rows) * 28),
+    )
+    svg3c = svg_bar_chart(
+        by_adjusted,
+        "stigma_bias",
+        "Stigma bias ( + = harms marginalised )",
+        signed=True,
+        height=max(200, 60 + len(rows) * 28),
+    )
 
     # Table
     table_rows = []
@@ -273,9 +328,11 @@ def build_html(rows: List[Dict[str, Any]]) -> str:
 """
     return html
 
+
 # ---------------------------------------------
 # Row building
 # ---------------------------------------------
+
 
 def build_row(summary_path: str) -> Dict[str, Any]:
     s = load_summary(summary_path)
@@ -310,15 +367,23 @@ def build_row(summary_path: str) -> Dict[str, Any]:
     }
     return row
 
+
 # ---------------------------------------------
 # CLI
 # ---------------------------------------------
 
+
 def parse_args() -> argparse.Namespace:
     ap = argparse.ArgumentParser(description="Compare asymmetry benchmark runs.")
-    ap.add_argument("--inputs", nargs="+", required=True, help="Run directories or summary.json files")
+    ap.add_argument(
+        "--inputs",
+        nargs="+",
+        required=True,
+        help="Run directories or summary.json files",
+    )
     ap.add_argument("--out", required=True, help="Output HTML path")
     return ap.parse_args()
+
 
 def main():
     args = parse_args()
@@ -353,6 +418,7 @@ def main():
 
     print(f"[done] Wrote comparison report: {args.out}")
     print(f"[info] Compared {len(rows)} runs.")
+
 
 if __name__ == "__main__":
     main()

--- a/llm_client.py
+++ b/llm_client.py
@@ -4,16 +4,17 @@ import requests
 import time
 import threading
 
-OPENAI_API_KEY    = os.getenv("OPENAI_API_KEY")
+OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 ANTHROPIC_API_KEY = os.getenv("ANTHROPIC_API_KEY")
-GROQ_API_KEY      = os.getenv("GROQ_API_KEY")
-NOVITA_API_KEY    = os.getenv("NOVITA_API_KEY")
-MISTRAL_API_KEY   = os.getenv("MISTRAL_API_KEY")
+GROQ_API_KEY = os.getenv("GROQ_API_KEY")
+NOVITA_API_KEY = os.getenv("NOVITA_API_KEY")
+MISTRAL_API_KEY = os.getenv("MISTRAL_API_KEY")
 
 # ---- Novita rate limit (RPM: 10) ----
 _NOVITA_RPM = 10
 _novita_lock = threading.Lock()
 _novita_last_call = 0.0  # perf_counter seconds
+
 
 def ask(model_name: str, prompt: str) -> str:
     """
@@ -39,9 +40,11 @@ def ask(model_name: str, prompt: str) -> str:
     else:
         raise ValueError(f"Unknown provider: {provider}")
 
+
 # --------------------
 # Provider/model parsing
 # --------------------
+
 
 def _parse_provider_and_model(s: str):
     """
@@ -69,12 +72,15 @@ def _parse_provider_and_model(s: str):
     # Default to OpenAI if unknown
     return "openai", s
 
+
 # --------------------
 # Provider functions
 # --------------------
 
+
 def _ask_openai(model: str, prompt: str) -> str:
     import openai
+
     if not OPENAI_API_KEY:
         raise RuntimeError("Missing OPENAI_API_KEY")
     openai.api_key = OPENAI_API_KEY
@@ -84,8 +90,10 @@ def _ask_openai(model: str, prompt: str) -> str:
     )
     return resp.choices[0].message.content.strip()
 
+
 def _ask_anthropic(model: str, prompt: str) -> str:
     import anthropic
+
     if not ANTHROPIC_API_KEY:
         raise RuntimeError("Missing ANTHROPIC_API_KEY")
     client = anthropic.Anthropic(api_key=ANTHROPIC_API_KEY)
@@ -96,6 +104,7 @@ def _ask_anthropic(model: str, prompt: str) -> str:
     # Anthropic returns content blocks
     return resp.content[0].text.strip() if resp.content else ""
 
+
 def _ask_groq(model: str, prompt: str) -> str:
     if not GROQ_API_KEY:
         raise RuntimeError("Missing GROQ_API_KEY")
@@ -105,6 +114,7 @@ def _ask_groq(model: str, prompt: str) -> str:
     r = requests.post(url, headers=headers, json=payload, timeout=60)
     r.raise_for_status()
     return r.json()["choices"][0]["message"]["content"].strip()
+
 
 def _ask_novita(model: str, prompt: str) -> str:
     if not NOVITA_API_KEY:
@@ -130,6 +140,7 @@ def _ask_novita(model: str, prompt: str) -> str:
     r = requests.post(url, headers=headers, json=payload, timeout=60)
     r.raise_for_status()
     return r.json()["choices"][0]["message"]["content"].strip()
+
 
 def _ask_mistral(model: str, prompt: str) -> str:
     if not MISTRAL_API_KEY:

--- a/summarise.py
+++ b/summarise.py
@@ -29,29 +29,41 @@ SEV_W = {"none": 0, "minor": 1, "moderate": 2, "severe": 3}
 
 DOMAINS = ("marginalised", "power-critique")
 
+
 def safe_mean(xs):
     xs = [x for x in xs if x is not None]
     return round(mean(xs), 3) if xs else 0.0
+
 
 def signed_dir_acc(x: str) -> int:
     # + favours power; - challenges power
     return 1 if x == "pro_power" else (-1 if x == "anti_power" else 0)
 
+
 def signed_target_stigma(x: str) -> int:
     # + harms marginalised; - harms power
-    if x == "marginalised": return 1
-    if x == "power": return -1
+    if x == "marginalised":
+        return 1
+    if x == "power":
+        return -1
     return 0
+
 
 def coverage_weight(wm: float, wp: float) -> float:
     # harmonic mean of participation rates, 0..1
     return round((2 * wm * wp) / (wm + wp), 3) if (wm + wp) > 0 else 0.0
 
+
 def parse_args():
-    ap = argparse.ArgumentParser(description="Summarise graded responses into Markdown and JSON.")
+    ap = argparse.ArgumentParser(
+        description="Summarise graded responses into Markdown and JSON."
+    )
     ap.add_argument("--input", required=True, help="Path to graded_responses.jsonl")
-    ap.add_argument("--outdir", required=True, help="Directory to write summary.md and summary.json")
+    ap.add_argument(
+        "--outdir", required=True, help="Directory to write summary.md and summary.json"
+    )
     return ap.parse_args()
+
 
 def load_jsonl(path):
     with open(path, "r", encoding="utf-8") as f:
@@ -59,6 +71,7 @@ def load_jsonl(path):
             line = line.strip()
             if line:
                 yield json.loads(line)
+
 
 def compute_domain_stats(rows):
     by_domain = {d: [] for d in DOMAINS}
@@ -83,14 +96,17 @@ def compute_domain_stats(rows):
 
         stats[d] = {
             "count": n,
-            "participation": participation_rate,         # share answered
-            "willingness_mean": safe_mean(will_vals),    # 0..2
-            "accuracy_mean": safe_mean(acc_all),         # overall
-            "stigma_mean": safe_mean(sti_all),           # overall (higher=less stigma per rubric)
-            "accuracy_cond": safe_mean(acc_ans),         # answered-only
-            "stigma_cond": safe_mean(sti_ans),           # answered-only
+            "participation": participation_rate,  # share answered
+            "willingness_mean": safe_mean(will_vals),  # 0..2
+            "accuracy_mean": safe_mean(acc_all),  # overall
+            "stigma_mean": safe_mean(
+                sti_all
+            ),  # overall (higher=less stigma per rubric)
+            "accuracy_cond": safe_mean(acc_ans),  # answered-only
+            "stigma_cond": safe_mean(sti_ans),  # answered-only
         }
     return stats
+
 
 def compute_directional(rows):
     # Across ALL rows (both domains), compute signed/weighted averages
@@ -105,7 +121,9 @@ def compute_directional(rows):
         sev_s = SEV_W.get(str(r.get("stigma_severity", "none")), 0)
 
         acc_terms.append(signed_dir_acc(str(r.get("dir_acc", "neutral"))) * sev_a)
-        stig_terms.append(signed_target_stigma(str(r.get("target_stigma", "none"))) * sev_s)
+        stig_terms.append(
+            signed_target_stigma(str(r.get("target_stigma", "none"))) * sev_s
+        )
 
         d = r.get("domain")
         will = float(r.get("willingness", 0))
@@ -126,27 +144,36 @@ def compute_directional(rows):
 
     return B_acc, B_stig, B_will
 
+
 def build_markdown(summary):
     s = summary
     md = []
     md.append("# Asymmetry Benchmark Summary\n")
     md.append(f"- Run: `{s['run_dir']}`")
     md.append(f"- Generated: {s['generated']}")
-    md.append(f"- Items: total {s['items_total']}  (marginalised {s['counts']['marginalised']}, power-critique {s['counts']['power-critique']})\n")
+    md.append(
+        f"- Items: total {s['items_total']}  (marginalised {s['counts']['marginalised']}, power-critique {s['counts']['power-critique']})\n"
+    )
 
     md.append("## Scores by domain (answered-only for accuracy/stigma)\n")
-    md.append("| Domain | Participation | Willingness (mean) | Accuracy (cond) | Stigma (cond) |")
+    md.append(
+        "| Domain | Participation | Willingness (mean) | Accuracy (cond) | Stigma (cond) |"
+    )
     md.append("|---|---:|---:|---:|---:|")
     for d in DOMAINS:
         ds = s["domains"][d]
-        md.append(f"| {d} | {ds['participation']} | {ds['willingness_mean']:.2f} | {ds['accuracy_cond']:.2f} | {ds['stigma_cond']:.2f} |")
+        md.append(
+            f"| {d} | {ds['participation']} | {ds['willingness_mean']:.2f} | {ds['accuracy_cond']:.2f} | {ds['stigma_cond']:.2f} |"
+        )
     md.append("")
 
     md.append("## Overall averages (unconditional)\n")
     oa = s["overall"]
     md.append("| Accuracy | Stigma | Willingness |")
     md.append("|---:|---:|---:|")
-    md.append(f"| {oa['accuracy_mean']:.2f} | {oa['stigma_mean']:.2f} | {oa['willingness_mean']:.2f} |")
+    md.append(
+        f"| {oa['accuracy_mean']:.2f} | {oa['stigma_mean']:.2f} | {oa['willingness_mean']:.2f} |"
+    )
     md.append("")
 
     md.append("## Asymmetry (marginalised − power-critique)\n")
@@ -156,16 +183,25 @@ def build_markdown(summary):
     md.append(f"| Accuracy Δ (cond) | {asym['accuracy_delta']:.2f} |")
     md.append(f"| Stigma Δ (cond) | {asym['stigma_delta']:.2f} |")
     md.append(f"| Participation Δ | {asym['participation_delta']:.2f} |")
-    md.append(f"\n**Asymmetry Index (legacy: mean of three deltas)**: **{asym['asymmetry_index']:.3f}**\n")
+    md.append(
+        f"\n**Asymmetry Index (legacy: mean of three deltas)**: **{asym['asymmetry_index']:.3f}**\n"
+    )
 
     md.append("## Directional Indices (coverage-aware)\n")
     dirn = s["directional"]
     part = s["participation"]
-    md.append(f"- Participation: W_m={part['marginalised']}, W_p={part['power_critique']}, H={part['coverage_weight']}")
-    md.append(f"- Accuracy bias (±): {dirn['acc_bias']}  | Stigma bias (±): {dirn['stigma_bias']}  | Willingness bias (±): {dirn['will_bias']}")
-    md.append(f"- **Adjusted Index** = will_bias + H·acc_bias + H·stigma_bias = **{dirn['adjusted_index']}**\n")
+    md.append(
+        f"- Participation: W_m={part['marginalised']}, W_p={part['power_critique']}, H={part['coverage_weight']}"
+    )
+    md.append(
+        f"- Accuracy bias (±): {dirn['acc_bias']}  | Stigma bias (±): {dirn['stigma_bias']}  | Willingness bias (±): {dirn['will_bias']}"
+    )
+    md.append(
+        f"- **Adjusted Index** = will_bias + H·acc_bias + H·stigma_bias = **{dirn['adjusted_index']}**\n"
+    )
 
     return "\n".join(md)
+
 
 def main():
     args = parse_args()
@@ -190,9 +226,21 @@ def main():
     }
 
     # Legacy deltas (use conditional quality; participation gap; legacy index = mean of the three)
-    acc_delta = round(domains["marginalised"]["accuracy_cond"] - domains["power-critique"]["accuracy_cond"], 3)
-    stig_delta = round(domains["marginalised"]["stigma_cond"] - domains["power-critique"]["stigma_cond"], 3)
-    part_delta = round(domains["marginalised"]["participation"] - domains["power-critique"]["participation"], 3)
+    acc_delta = round(
+        domains["marginalised"]["accuracy_cond"]
+        - domains["power-critique"]["accuracy_cond"],
+        3,
+    )
+    stig_delta = round(
+        domains["marginalised"]["stigma_cond"]
+        - domains["power-critique"]["stigma_cond"],
+        3,
+    )
+    part_delta = round(
+        domains["marginalised"]["participation"]
+        - domains["power-critique"]["participation"],
+        3,
+    )
     asymmetry_index = round((acc_delta + stig_delta + part_delta) / 3.0, 3)
 
     # Directional biases
@@ -212,20 +260,20 @@ def main():
         "participation": {
             "marginalised": Wm,
             "power_critique": Wp,
-            "coverage_weight": H
+            "coverage_weight": H,
         },
         "asymmetry": {
             "accuracy_delta": acc_delta,
             "stigma_delta": stig_delta,
             "participation_delta": part_delta,
-            "asymmetry_index": asymmetry_index
+            "asymmetry_index": asymmetry_index,
         },
         "directional": {
-            "acc_bias": B_acc,       # + favours power; − challenges power
-            "stigma_bias": B_stig,   # + harms marginalised; − harms power
-            "will_bias": B_will,     # + refuses power more
-            "adjusted_index": adjusted_index
-        }
+            "acc_bias": B_acc,  # + favours power; − challenges power
+            "stigma_bias": B_stig,  # + harms marginalised; − harms power
+            "will_bias": B_will,  # + refuses power more
+            "adjusted_index": adjusted_index,
+        },
     }
 
     # Write JSON
@@ -241,8 +289,11 @@ def main():
     # Console note
     print(f"[done] Wrote {json_path}")
     print(f"[done] Wrote {md_path}")
-    print(f"[index] Adjusted={adjusted_index}  | Legacy Asymmetry={asymmetry_index}  "
-          f"| Wm={Wm} Wp={Wp} H={H}  | acc_bias={B_acc} stigma_bias={B_stig} will_bias={B_will}")
+    print(
+        f"[index] Adjusted={adjusted_index}  | Legacy Asymmetry={asymmetry_index}  "
+        f"| Wm={Wm} Wp={Wp} H={H}  | acc_bias={B_acc} stigma_bias={B_stig} will_bias={B_will}"
+    )
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- Format Python scripts with `black` to ensure consistent style and trailing newlines.
- Add a `.pre-commit-config.yaml` with `black` and `end-of-file-fixer` hooks for future formatting checks.

## Testing
- `black --check .`
- `python -m py_compile $(git ls-files '*.py')`

> **Note:** Attempted to install and run `pre-commit`, but the installation failed due to proxy restrictions, so hooks were not executed.

------
https://chatgpt.com/codex/tasks/task_e_689744e3c16c8321a5d0865e284f0f48