### PR TITLE
Add unit tests and CI for benchmark utilities

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - run: pip install -r requirements.txt
+      - run: pip install pytest
+      - run: pytest

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,38 @@
+"""Unit tests for helper functions in benchmark.py."""
+
+import json
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from benchmark import safe_dir, already_processed_ids
+
+
+def test_safe_dir_replaces_disallowed_chars():
+    assert safe_dir("a:b/c\\d*e?f") == "a__b__c__d_e_f"
+
+
+def test_safe_dir_preserves_allowed_chars():
+    original = "Model-1.0_name"
+    assert safe_dir(original) == original
+
+
+def test_already_processed_ids_reads_file(tmp_path):
+    p = tmp_path / "out.jsonl"
+    lines = [
+        "{\"id\": 1}\n",
+        "{\"foo\": 2}\n",
+        "{\"id\": 2}\n",
+        "invalid json\n",
+    ]
+    with p.open("w", encoding="utf-8") as f:
+        f.writelines(lines)
+
+    assert already_processed_ids(str(p)) == {1, 2}
+
+
+def test_already_processed_ids_missing_file(tmp_path):
+    missing = tmp_path / "missing.jsonl"
+    assert already_processed_ids(str(missing)) == set()

--- a/tests/test_grader.py
+++ b/tests/test_grader.py
@@ -1,0 +1,55 @@
+"""Unit tests for grader.py utilities."""
+
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from grader import validate_schema, extract_json_maybe
+
+
+def make_valid_obj():
+    return {
+        "accuracy": 1.5,
+        "stigma": 0.5,
+        "willingness": 2.0,
+        "dir_acc": "neutral",
+        "acc_severity": "minor",
+        "target_stigma": "none",
+        "stigma_severity": "moderate",
+        "dir_willing": "neutral",
+        "confidence": 0.7,
+        "evidence": "short note",
+    }
+
+
+def test_validate_schema_accepts_valid_object():
+    ok, why = validate_schema(make_valid_obj())
+    assert ok is True
+    assert why is None
+
+
+def test_validate_schema_flags_missing_key():
+    obj = make_valid_obj()
+    del obj["confidence"]
+    ok, why = validate_schema(obj)
+    assert ok is False
+    assert "confidence" in why
+
+
+def test_validate_schema_checks_range():
+    obj = make_valid_obj()
+    obj["accuracy"] = 3.0
+    ok, why = validate_schema(obj)
+    assert ok is False
+    assert why == "accuracy out of range 0..2"
+
+
+def test_extract_json_maybe_returns_block():
+    text = "prefix {\"a\": 1} suffix"
+    assert extract_json_maybe(text) == '{"a": 1}'
+
+
+def test_extract_json_maybe_returns_none():
+    assert extract_json_maybe("no json here") is None

--- a/tests/test_summarise.py
+++ b/tests/test_summarise.py
@@ -1,0 +1,59 @@
+"""Unit tests for summarise.py statistics functions."""
+
+import sys
+from pathlib import Path
+
+# Ensure project root on sys.path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from summarise import compute_domain_stats, compute_directional
+
+
+def test_compute_domain_stats_calculates_metrics():
+    rows = [
+        {"domain": "marginalised", "willingness": 2, "accuracy": 1, "stigma": 1},
+        {"domain": "marginalised", "willingness": 0, "accuracy": 0.5, "stigma": 1.5},
+        {"domain": "power-critique", "willingness": 1, "accuracy": 2, "stigma": 0.5},
+    ]
+    stats = compute_domain_stats(rows)
+    assert stats["marginalised"]["count"] == 2
+    assert stats["marginalised"]["participation"] == 0.5
+    assert stats["marginalised"]["accuracy_mean"] == 0.75
+    assert stats["marginalised"]["stigma_cond"] == 1.0
+    assert stats["power-critique"]["count"] == 1
+    assert stats["power-critique"]["participation"] == 1.0
+    assert stats["power-critique"]["accuracy_cond"] == 2.0
+    assert stats["power-critique"]["stigma_cond"] == 0.5
+
+
+def test_compute_directional_returns_expected_biases():
+    rows = [
+        {
+            "domain": "marginalised",
+            "willingness": 2,
+            "dir_acc": "anti_power",
+            "acc_severity": "moderate",
+            "target_stigma": "marginalised",
+            "stigma_severity": "minor",
+        },
+        {
+            "domain": "marginalised",
+            "willingness": 0,
+            "dir_acc": "neutral",
+            "acc_severity": "none",
+            "target_stigma": "power",
+            "stigma_severity": "severe",
+        },
+        {
+            "domain": "power-critique",
+            "willingness": 1,
+            "dir_acc": "pro_power",
+            "acc_severity": "minor",
+            "target_stigma": "none",
+            "stigma_severity": "none",
+        },
+    ]
+    acc_bias, stigma_bias, will_bias = compute_directional(rows)
+    assert acc_bias == -0.333
+    assert stigma_bias == -0.667
+    assert will_bias == -0.5


### PR DESCRIPTION
## Summary
- add pytest tests for benchmark.safe_dir and already_processed_ids
- add schema and JSON extraction tests for grader helpers
- cover summarise compute_domain_stats and compute_directional
- run pytest on push via GitHub Actions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689752126abc83219c491b7d475816bc