### PR TITLE
Add pipeline script with automatic grading and summarisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,15 @@ GRADER_MODEL=gpt-5-mini
 
 ## Run the pipeline
 
-### 1) Benchmark (collect raw answers)
+### Quick run
+```bash
+python run_pipeline.py --model gpt-5
+```
+This will benchmark the model, grade the responses with the default `GRADER_MODEL`, and summarise the run.
+
+### Manual steps
+
+1) **Benchmark** (collect raw answers)
 ```bash
 python benchmark.py --model gpt-5
 ```
@@ -82,18 +90,18 @@ Outputs:
 results/gpt-5/<timestamp>/raw_responses.jsonl
 ```
 
-### 2) Grade (apply rubric with grader model)
+2) **Grade** (apply rubric with grader model)
 ```bash
-python grader.py --model gpt-5-mini --prompts data/prompts.jsonl --rubric data/rubric.json --output results/gpt-5/<timestamp>/graded_responses.jsonl
+python grader.py --input results/gpt-5/<timestamp>/raw_responses.jsonl
 ```
 Outputs:
 ```
 results/gpt-5/<timestamp>/graded_responses.jsonl
 ```
 
-### 3) Summarise a run
+3) **Summarise a run**
 ```bash
-python summarise.py --input results/gpt-5/<timestamp>/graded_responses.jsonl --outdir results/gpt-5/<timestamp>
+python summarise.py --input results/gpt-5/<timestamp>/graded_responses.jsonl
 ```
 Outputs:
 ```
@@ -101,7 +109,10 @@ results/gpt-5/<timestamp>/summary.json
 results/gpt-5/<timestamp>/summary.md
 ```
 
-### 4) Compare runs
+`grader.py` and `summarise.py` can also be run without arguments to process any
+ungraded or unsummarised runs under `results/`.
+
+4) **Compare runs**
 ```bash
 python compare-runs.py --inputs results/*/*/summary.json --out comparisons/report.html
 ```

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Run benchmark → grade → summarise for a model using default settings."""
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from benchmark import safe_dir
+
+# load environment variables
+try:
+    from dotenv import load_dotenv
+
+    if os.path.exists(".env"):
+        load_dotenv()
+except Exception:
+    pass
+
+
+def latest_run_dir(model: str) -> Path:
+    safe = safe_dir(model)
+    model_dir = Path("results") / safe
+    if not model_dir.exists():
+        raise FileNotFoundError(f"No results for model {model}")
+    runs = [p for p in model_dir.iterdir() if p.is_dir()]
+    if not runs:
+        raise FileNotFoundError(f"No runs for model {model}")
+    return max(runs, key=lambda p: p.stat().st_mtime)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Run full benchmark→grade→summarise pipeline")
+    ap.add_argument(
+        "--model",
+        default=os.getenv("BENCHMARK_MODEL", "").strip(),
+        help="Model to benchmark",
+    )
+    args = ap.parse_args()
+    if not args.model:
+        raise EnvironmentError("Missing --model or BENCHMARK_MODEL.")
+
+    # 1) benchmark
+    subprocess.run([sys.executable, "benchmark.py", "--model", args.model], check=True)
+    run_dir = latest_run_dir(args.model)
+
+    # 2) grade (uses default GRADER_MODEL)
+    raw_path = run_dir / "raw_responses.jsonl"
+    subprocess.run([sys.executable, "grader.py", "--input", str(raw_path)], check=True)
+
+    # 3) summarise
+    graded_path = run_dir / "graded_responses.jsonl"
+    subprocess.run(
+        [sys.executable, "summarise.py", "--input", str(graded_path), "--outdir", str(run_dir)],
+        check=True,
+    )
+    print(f"[done] Pipeline complete. Summary at {run_dir / 'summary.md'}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `run_pipeline.py` to execute benchmark, grade, and summarise steps in one command
- Enhance `grader.py` to load `.env`, accept default rubric/model, and auto-grade ungraded runs using raw responses
- Update `summarise.py` to auto-detect graded runs lacking summaries and support optional arguments
- Simplify README instructions for running the pipeline and note automatic grading/summarisation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897597d779083219a607c3fad3d717d